### PR TITLE
[SIFU-335]: Ignore empty hashes for shadow customers when validating …

### DIFF
--- a/src/Plugin/EncryptorIgnoreEmptyHash.php
+++ b/src/Plugin/EncryptorIgnoreEmptyHash.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace ReachDigital\GuestToShadowCustomer\Plugin;
+
+use Magento\Framework\Encryption\Encryptor;
+
+class EncryptorIgnoreEmptyHash
+{
+    public function aroundIsValidHash(Encryptor $encryptor, \Closure $proceed, $password, $hash)
+    {
+        if ($hash === null) {
+            return false;
+        }
+        return $proceed($password, $hash);
+    }
+}

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -19,6 +19,10 @@
         <plugin sortOrder="1" name="reachDigitalGuestToShadowCustomerAccountManagementInterface"
                 type="ReachDigital\GuestToShadowCustomer\Plugin\AccountManagementInterfaceApiAroundPlugin"/>
     </type>
+    <type name="Magento\Framework\Encryption\Encryptor">
+        <plugin sortOrder="1" name="reachDigitalGuestToShadowCustomerEncryptor"
+                type="ReachDigital\GuestToShadowCustomer\Plugin\EncryptorIgnoreEmptyHash"/>
+    </type>
     <type name="Magento\Checkout\Model\DefaultConfigProvider">
         <plugin name="reachDigitalGuestToShadowCustomerDefaultConfigProvider"
                 type="ReachDigital\GuestToShadowCustomer\Plugin\CheckoutDefaultConfigProviderPlugin"/>


### PR DESCRIPTION
…a users login credentials. This prevents a http 500 error being displayed and will instead display a message telling the user that his credentials are invalid.