### PR TITLE
DAX-534 Only trigger shadow customer creation if quote is guest

### DIFF
--- a/src/Plugin/ConvertGuestQuoteToShadowCustomerBeforeSubmitPlugin.php
+++ b/src/Plugin/ConvertGuestQuoteToShadowCustomerBeforeSubmitPlugin.php
@@ -49,7 +49,7 @@ class ConvertGuestQuoteToShadowCustomerBeforeSubmitPlugin
             $quote->getStore()
         );
 
-        if ($enabled === true) {
+        if ($enabled === true && $quote->getCustomerIsGuest()) {
             $this->convertGuestQuoteToShadowCustomer->execute($quote);
 
             $quote->getShippingAddress()->setCustomerId($quote->getCustomer()->getId());


### PR DESCRIPTION
Under certain conditions, i.e. if customer e-mail was changed after the quote was created, a shadow customer was created for the old e-mail adress on the quote, even though the quote was not a guest quote, and was linked to an existing customer.

This shadow customer would then trip up certain validations done on the quote, and cause the order submission to fail.